### PR TITLE
Fix RecursiveMode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn main() -> notify::Result<()> {
         std::process::exit(1);
     }
 
-    watcher.watch(input_dir_path, RecursiveMode::Recursive)?;
+    watcher.watch(input_dir_path, RecursiveMode::NonRecursive)?;
 
     loop {
         match rx.recv() {


### PR DESCRIPTION
Fixed to use `NonRecursive` mode when specifying Input file directory.
This is because the `Recursive` mode recursively traverses directories, so that unintended file changes will be detected if, for example, the output directory is under the input directory.